### PR TITLE
add reserved Cinder status

### DIFF
--- a/pkg/metrics/cinder.go
+++ b/pkg/metrics/cinder.go
@@ -21,7 +21,7 @@ var (
 	defaultLabels = []string{"id", "description", "name", "status", "cinder_availability_zone", "volume_type", "pvc_name", "pvc_namespace", "pv_name", "pv_storage_class", "pv_reclaim_policy", "pv_fs_type"}
 
 	// possible cinder states
-	cinderStates = []string{"available", "error", "creating", "deleting", "in-use", "attaching", "detaching", "error_deleting", "maintenance"}
+	cinderStates = []string{"available", "error", "creating", "deleting", "in-use", "attaching", "detaching", "error_deleting", "maintenance", "reserved"}
 
 	cinderQuotaVolumes         *prometheus.GaugeVec
 	cinderQuotaVolumesGigabyte *prometheus.GaugeVec


### PR DESCRIPTION
OpenStack also knows the `reserved` Cinder state:

```
$ openstack volume list
+--------------------------------------+-------------------------------------------------------------+-----------+------+------------------------------------------------+
| ID                                   | Name                                                        | Status    | Size | Attached to                                    |
+--------------------------------------+-------------------------------------------------------------+-----------+------+------------------------------------------------+
| ba49a7e4-4a3b-4ee4-a001-4fe4169242bb | pvc-793a6ca0-e356-11e9-ab4c-fa163e1bb537                    | reserved  |    8 |                                                |
+--------------------------------------+-------------------------------------------------------------+-----------+------+------------------------------------------------+
```

`reserved` seems to denote disks that currently await creation or similar operations and is a transient state, but triggered some alerts with us because a disk did not have state for that time span.